### PR TITLE
Add ServiceAccountName, remove outer for loop, update default restart count

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,7 +1,7 @@
 kleaner:
   reasons:
     - reason: "CrashLoopBackOff"
-      restartThreshold: 100
+      restartThreshold: 144
       deleteFuncString: "DeleteCrash"
     - reason: "ImagePullBackOff"
       deleteFuncString: "DeleteGeneric"

--- a/install/cronjob.yaml
+++ b/install/cronjob.yaml
@@ -7,13 +7,10 @@ spec:
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
-        metadata:
-          creationTimestamp: null
         spec:
+          serviceAccountName: kubernetes-deployment-crawler
           containers:
             - args:
               image: docker.io/attcloudnativelabs/kubernetes-deployment-crawler:v0.0.1-alpha
@@ -27,6 +24,6 @@ spec:
           schedulerName: default-scheduler
           securityContext: {}
           terminationGracePeriodSeconds: 30
-  schedule: '0 10 * * *'
+  schedule: '0 17 * * *'
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/main.go
+++ b/main.go
@@ -70,46 +70,44 @@ func main() {
 
 	fmt.Println("Beginning the crawl.")
 
-	for {
-		// get a list of pods for all namespaces
-		pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
-		if err != nil {
-			panic(err.Error())
-		}
-		fmt.Println("Got list of pods.")
+	// get a list of pods for all namespaces
+	pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println("Got list of pods.")
 
-		for _, pod := range pods.Items {
-		StatusLoop:
-			for _, status := range pod.Status.ContainerStatuses {
-				waiting := status.State.Waiting
-				if waiting != nil {
-					reason := waiting.Reason
-					if crawlerConfigDetails, ok := waitingReasons[reason]; ok {
-						fmt.Printf("Waiting reason match. %s/%s has a waiting reason of: %s", pod.Namespace,
-							pod.OwnerReferences[0].Name, reason)
-						rs, err := clientset.AppsV1().ReplicaSets(pod.Namespace).Get(pod.OwnerReferences[0].Name, metav1.GetOptions{})
+	for _, pod := range pods.Items {
+	StatusLoop:
+		for _, status := range pod.Status.ContainerStatuses {
+			waiting := status.State.Waiting
+			if waiting != nil {
+				reason := waiting.Reason
+				if crawlerConfigDetails, ok := waitingReasons[reason]; ok {
+					fmt.Printf("Waiting reason match. %s/%s has a waiting reason of: %s", pod.Namespace,
+						pod.OwnerReferences[0].Name, reason)
+					rs, err := clientset.AppsV1().ReplicaSets(pod.Namespace).Get(pod.OwnerReferences[0].Name, metav1.GetOptions{})
+					if err != nil {
+						fmt.Printf("Error retrieving ReplicaSets. Error: %s\n", err.Error())
+						continue StatusLoop
+					}
+					if rs.OwnerReferences != nil {
+						deploy, err := clientset.AppsV1().Deployments(pod.Namespace).Get(rs.OwnerReferences[0].Name, metav1.GetOptions{})
 						if err != nil {
-							fmt.Printf("Error retrieving ReplicaSets. Error: %s\n", err.Error())
+							fmt.Printf("Error retrieving Deployments. Error: %s\n", err.Error())
 							continue StatusLoop
 						}
-						if rs.OwnerReferences != nil {
-							deploy, err := clientset.AppsV1().Deployments(pod.Namespace).Get(rs.OwnerReferences[0].Name, metav1.GetOptions{})
+						if deploy != nil && deploy.Name != "" { // indicates something to be deleted
+							_, err = crawlerConfigDetails.DeleteFunction(clientset.AppsV1().Deployments(pod.Namespace), deploy, int(status.RestartCount), crawlerConfigDetails.RestartThreshold)
 							if err != nil {
-								fmt.Printf("Error retrieving Deployments. Error: %s\n", err.Error())
+								fmt.Printf("Error deleting Deployment. Error: %s\n", err.Error())
 								continue StatusLoop
 							}
-							if deploy != nil && deploy.Name != "" { // indicates something to be deleted
-								_, err = crawlerConfigDetails.DeleteFunction(clientset.AppsV1().Deployments(pod.Namespace), deploy, int(status.RestartCount), crawlerConfigDetails.RestartThreshold)
-								if err != nil {
-									fmt.Printf("Error deleting Deployment. Error: %s\n", err.Error())
-									continue StatusLoop
-								}
-							} else {
-								fmt.Println("No deployment found.")
-							}
 						} else {
-							fmt.Println("No replica set owner reference.")
+							fmt.Println("No deployment found.")
 						}
+					} else {
+						fmt.Println("No replica set owner reference.")
 					}
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func DeleteCrash(deploymentInterface typedappsv1.DeploymentInterface, deployment
 		return DeleteGeneric(deploymentInterface, deployment, restarts, restartThreshold)
 	} else {
 		fmt.Printf("%s/%s is in a CrashLoopBackOff state, but doesn't meet the restart threshold. " +
-			"Restarts/Threshold = %v/%v", deployment.Namespace, deployment.Name, restarts, restartThreshold)
+			"Restarts/Threshold = %v/%v\n", deployment.Namespace, deployment.Name, restarts, restartThreshold)
 		return false, nil
 	}
 }
@@ -84,7 +84,7 @@ func main() {
 			if waiting != nil {
 				reason := waiting.Reason
 				if crawlerConfigDetails, ok := waitingReasons[reason]; ok {
-					fmt.Printf("Waiting reason match. %s/%s has a waiting reason of: %s", pod.Namespace,
+					fmt.Printf("Waiting reason match. %s/%s has a waiting reason of: %s\n", pod.Namespace,
 						pod.OwnerReferences[0].Name, reason)
 					rs, err := clientset.AppsV1().ReplicaSets(pod.Namespace).Get(pod.OwnerReferences[0].Name, metav1.GetOptions{})
 					if err != nil {


### PR DESCRIPTION
We need ```serviceAccountName: kubernetes-deployment-crawler``` in the cronjob.yaml or else k8s will use the ```default``` ServiceAccount. Credit @gbraxton with that.

This PR also removes the outer for loop in main.go.

Lastly, this PR also updates the default restart threshold to 144.